### PR TITLE
fix: Use pointer to cover both value-receiver and pointer-receiver De…

### DIFF
--- a/main.go
+++ b/main.go
@@ -526,8 +526,9 @@ func generateDebugCodeByCategory(grp *jen.Group, fieldType ast.Expr, receiverId,
 	default:
 		// Complex types: runtime interface check for DebugMap() — works for same-package,
 		// cross-package, and external types uniformly.
+		// Use pointer to cover both value-receiver and pointer-receiver DebugMap() methods.
 		grp.If(
-			jen.List(jen.Id("dm"), jen.Id("ok")).Op(":=").Id("any").Call(jen.Id(receiverId).Dot(fieldName)).Assert(
+			jen.List(jen.Id("dm"), jen.Id("ok")).Op(":=").Id("any").Call(jen.Op("&").Id(receiverId).Dot(fieldName)).Assert(
 				jen.Interface(jen.Id("DebugMap").Params().Map(jen.String()).Any()),
 			),
 			jen.Id("ok"),

--- a/testdata/cross_package/golden.go
+++ b/testdata/cross_package/golden.go
@@ -44,14 +44,14 @@ func (c *CrossPackage) DebugMap() map[string]any {
 	} else {
 		debugMap["Name"] = c.Name
 	}
-	if dm, ok := any(c.Timestamp).(interface {
+	if dm, ok := any(&c.Timestamp).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["Timestamp"] = dm.DebugMap()
 	} else {
 		debugMap["Timestamp"] = c.Timestamp
 	}
-	if dm, ok := any(c.Duration).(interface {
+	if dm, ok := any(&c.Duration).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["Duration"] = dm.DebugMap()

--- a/testdata/database_sql/golden.go
+++ b/testdata/database_sql/golden.go
@@ -40,7 +40,7 @@ func (d *DatabaseConfig) ToOption() DatabaseConfigOption {
 func (d *DatabaseConfig) DebugMap() map[string]any {
 	debugMap := map[string]any{}
 	debugMap["ConnectionString"] = "(sensitive)"
-	if dm, ok := any(d.MaxConnections).(interface {
+	if dm, ok := any(&d.MaxConnections).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["MaxConnections"] = dm.DebugMap()

--- a/testdata/generics/golden.go
+++ b/testdata/generics/golden.go
@@ -43,21 +43,21 @@ func (g *GenericConfig) ToOption() GenericConfigOption {
 // DebugMap returns a map form of GenericConfig for debugging
 func (g *GenericConfig) DebugMap() map[string]any {
 	debugMap := map[string]any{}
-	if dm, ok := any(g.StringContainer).(interface {
+	if dm, ok := any(&g.StringContainer).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["StringContainer"] = dm.DebugMap()
 	} else {
 		debugMap["StringContainer"] = g.StringContainer
 	}
-	if dm, ok := any(g.IntContainer).(interface {
+	if dm, ok := any(&g.IntContainer).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["IntContainer"] = dm.DebugMap()
 	} else {
 		debugMap["IntContainer"] = g.IntContainer
 	}
-	if dm, ok := any(g.StringIntPair).(interface {
+	if dm, ok := any(&g.StringIntPair).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["StringIntPair"] = dm.DebugMap()

--- a/testdata/nested/golden.go
+++ b/testdata/nested/golden.go
@@ -41,7 +41,7 @@ func (o *OuterConfig) DebugMap() map[string]any {
 	} else {
 		debugMap["Name"] = o.Name
 	}
-	if dm, ok := any(o.Nested).(interface {
+	if dm, ok := any(&o.Nested).(interface {
 		DebugMap() map[string]any
 	}); ok {
 		debugMap["Nested"] = dm.DebugMap()


### PR DESCRIPTION
…bugMap() methods

## Description

In Go, methods can be defined on a value (`func (c Config) Foo()`) or on a pointer (`func (c  *Config) Foo()`).

The type assertion:
                                                                                               
`any(c.Something).(interface{ DebugMap() map[string]any })`
                                                                                               
 will fail if `DebugMap` was defined on a pointer. 

## Testing

In SpiceDB